### PR TITLE
Use HTTPS to load JS libraries

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.25/angular.min.js"></script> 
     <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0rc1/angular-route.min.js"></script> 
-    <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.2.6/angular-animate.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.6/angular-animate.js"></script>
     <script src="js/app.js"></script>
   </body>
 </html>


### PR DESCRIPTION
If you visit https://kona.github.io/ on Chrome you get a blank page because it tries to load an HTTP resource.